### PR TITLE
Fix F# examples to match changed builder custom operation names

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ table {
     column_text ""
     column (tableColumn { header_text "Feature"; centerd })
     row_text [| "Baz"; "[green]Qux[/]" |]
-    row [| markup { text "[blue]Corgi[/]" }; panel { content "Waldo" } |]
+    row [| markup { text "[blue]Corgi[/]" }; panel { content_text "Waldo" } |]
 } |> AnsiConsole.Write
 ```
 
@@ -67,7 +67,7 @@ With F# + FsSpectre:
 barChart {
     width 60
     label "[green bold underline]Number of fruits[/]"
-    center_label
+    centered_label
     item ("Apple", 12, Color.Yellow)
     item ("Oranges", 54, Color.Green)
     item ("Bananas", 33, Color.Red)


### PR DESCRIPTION
The F# examples in the readme have 2 errors, probably due to updates on the builder CustomOperation names.
This change updates the # table and barchart examples to the new names - specifically 'content' --> 'content_text' and 'center_label' --> 'centered_label'