### PR TITLE
fix columns operation

### DIFF
--- a/src/FsSpectre/Live/Progress.fs
+++ b/src/FsSpectre/Live/Progress.fs
@@ -25,7 +25,7 @@ module ProgressBuilder =
         member __.Yield _ = ProgressConfig<'T>.Default
 
         member __.Run(config: ProgressConfig<'T>) =
-            let progress = AnsiConsole.Progress()
+            let progress = AnsiConsole.Progress().Columns(config.Columns)
             progress.AutoRefresh <- config.AutoRefresh
             progress.AutoClear <- config.AutoClear
             progress.HideCompleted <- config.HideCompleted
@@ -69,7 +69,7 @@ module ProgressBuilder =
         member __.Yield _ = ProgressAsyncConfig<'T>.Default
 
         member __.Run(config: ProgressAsyncConfig<'T>) =
-            let progress = AnsiConsole.Progress()
+            let progress = AnsiConsole.Progress().Columns(config.Columns)
             progress.AutoRefresh <- config.AutoRefresh
             progress.AutoClear <- config.AutoClear
             progress.HideCompleted <- config.HideCompleted


### PR DESCRIPTION
I was trying to use the `columns` operation to add a `RemainingTimeColumn` field to a progress output, but it had no effect. Checking the code, it is built but not passed in `Run`.