### PR TITLE
feat: lower FSharp.Core requirements

### DIFF
--- a/src/FsSpectre/FsSpectre.fsproj
+++ b/src/FsSpectre/FsSpectre.fsproj
@@ -29,7 +29,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="8.0.200" />
+    <PackageReference Update="FSharp.Core" Version="5.0.2" />
     <PackageReference Include="Spectre.Console" Version="0.49.1" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Hello,

Thanks you for this project it makes it more fun to work with Spectre.Console.

This PR is a proposition to lower FSharp.Core, I made a PR instead of an issue because it like that it is easier showcase the impact on the code (basically none 😅).

When authoring F# libraries, it is recommended to make FSharp.Core dependency as low as possible. It allows a library to reach a larger range of codebase.

Otherwise people will get warning like:

> Detected package downgrade: FSharp.Core from 8.0.200 to 8.0.101. Reference the package directly from the project to select a different version. 

For `fs-spectre` it is perhaps possible to go even lower but based on my experience  targeting 5.0.2 works great. It gives you access to a lot of F# new goodies while allowing to reach a wide range of project.

You can read more about FSharp.Core management [here](https://fsharp.github.io/fsharp-compiler-docs/fsharp-core-notes.html#Guidance-for-package-authors)